### PR TITLE
Move username to node definition and password to ket storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ and `WinRM File Copier` as Default Node File Copier
 
 Settings:  
 `Kerberos Realm`  Put here fqdn of your realm in case your computer is part of AD domain  
-`Username` Put here username for negotiate, plaintext or ssl auth  
-`Password` Put here password for negotiate, plaintext or ssl auth  
+`Username` (Removed, it will taken at node label) Put here username for negotiate, plaintext or ssl auth  
+`Password` (Removed, it will taken at node label or using Password Storage)Put here password for negotiate, plaintext or ssl auth  
 `Auth type` choose here negotiate, kerberos, plaintext or ssl  
 `WinRM port` set port for winrm (Default: 5985/5986 for http/https)  
 `Shell` choose here powershell, cmd or wql  
 `WinRM timeout` put here time in seconds (useful for long running commands)  
+`Password Storage` Put the password using the Key Storage
 
 ![](http://cl.ly/1S1D2C070Z1T/Screenshot%202016-01-05%2016.51.53.png)
 

--- a/contents/winrmcp.rb
+++ b/contents/winrmcp.rb
@@ -1,17 +1,21 @@
 #!/usr/bin/ruby
 gem 'winrm-fs', '= 0.4.3'
 require 'winrm-fs'
+
 auth = ENV['RD_CONFIG_AUTHTYPE']
-user = ENV['RD_CONFIG_USER'].dup # for some reason these strings is frozen, so we duplicate it
-pass = ENV['RD_CONFIG_PASS'].dup
+user = ENV['RD_NODE_USERNAME'] #take the username from node
+pass = ENV['RD_CONFIG_PASSWORDSTORAGEPATH'].dup  #take the password from password storage path
 host = ENV['RD_NODE_HOSTNAME']
 port = ENV['RD_CONFIG_WINRMPORT']
 shell = ENV['RD_CONFIG_SHELL']
 realm = ENV['RD_CONFIG_KRB5_REALM']
+command = ENV['RD_EXEC_COMMAND']
 override = ENV['RD_CONFIG_ALLOWOVERRIDE']
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
 pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
+no_ssl_peer_verification=ENV['RD_CONFIG_NOSSLPV']
+
 
 file = ARGV[1]
 dest = ARGV[2]
@@ -51,7 +55,7 @@ when 'kerberos'
 when 'plaintext'
   winrm = WinRM::WinRMWebService.new(endpoint, :plaintext, user: user, pass: pass, disable_sspi: true)
 when 'ssl'
-  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true)
+  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true, :no_ssl_peer_verification => no_ssl_peer_verification)
 else
   fail "Invalid authtype '#{auth}' specified, expected: kerberos, plaintext, ssl."
 end

--- a/contents/winrmexe.rb
+++ b/contents/winrmexe.rb
@@ -2,8 +2,8 @@
 gem 'winrm', '= 1.8.1'
 require 'winrm'
 auth = ENV['RD_CONFIG_AUTHTYPE']
-user = ENV['RD_CONFIG_USER'].dup # for some reason these strings is frozen, so we duplicate it
-pass = ENV['RD_CONFIG_PASS'].dup
+user = ENV['RD_NODE_USERNAME'] #take the username from node
+pass = ENV['RD_CONFIG_PASSWORDSTORAGEPATH'].dup  #take the password from password storage path
 host = ENV['RD_NODE_HOSTNAME']
 port = ENV['RD_CONFIG_WINRMPORT']
 shell = ENV['RD_CONFIG_SHELL']
@@ -13,6 +13,7 @@ override = ENV['RD_CONFIG_ALLOWOVERRIDE']
 host = ENV['RD_OPTION_WINRMHOST'] if ENV['RD_OPTION_WINRMHOST'] && (override == 'host' || override == 'all')
 user = ENV['RD_OPTION_WINRMUSER'].dup if ENV['RD_OPTION_WINRMUSER'] && (override == 'user' || override == 'all')
 pass = ENV['RD_OPTION_WINRMPASS'].dup if ENV['RD_OPTION_WINRMPASS'] && (override == 'user' || override == 'all')
+no_ssl_peer_verification=ENV['RD_CONFIG_NOSSLPV']
 
 if auth == 'ssl'
   endpoint = "https://#{host}:#{port}/wsman"
@@ -64,6 +65,7 @@ if ENV['RD_JOB_LOGLEVEL'] == 'DEBUG'
   puts "realm => #{realm}"
   puts "endpoint => #{endpoint}"
   puts "user => #{user}"
+  puts "no_ssl_peer_verification => #{no_ssl_peer_verification}"
   puts 'pass => ********'
   # puts "pass => #{pass}" # uncomment it for full auth debugging
   puts "command => #{ENV['RD_EXEC_COMMAND']}"
@@ -99,7 +101,7 @@ when 'kerberos'
 when 'plaintext'
   winrm = WinRM::WinRMWebService.new(endpoint, :plaintext, user: user, pass: pass, disable_sspi: true)
 when 'ssl'
-  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true)
+  winrm = WinRM::WinRMWebService.new(endpoint, :ssl, user: user, pass: pass, disable_sspi: true, :no_ssl_peer_verification => no_ssl_peer_verification)
 else
   fail "Invalid authtype '#{auth}' specified, expected: kerberos, plaintext, ssl."
 end

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,9 @@
-name: rd-winrm-plugin
-version: 1.5.1
-rundeckPluginVersion: 1.0
-author: Volodymyr Babchynskyy
-date: 26.10.2015
+name: "rd-winrm-plugin"
+rundeckPluginVersion: 1.2
+author: "© 2017, Rundeck, Inc."
+date: "Fri Feb 03 22:29:35 UTC 2017"
+version: "1.5.2"
+url: "http://rundeck.com"
 providers:
   - name: WinRMexe
     title: WinRM Executor
@@ -18,29 +19,25 @@ providers:
         title: Kerberos Realm
         type: String
         required: false
-        description: "Kerberos Realm FQDN in capital letters"
+        description: "Kerberos Realm FQDN in capital letters.Can be overridden by a Node attribute named 'krb5_realm'."
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "krb5_realm"
-      - name: user
-        title: Username
-        description: "Username in DOMAIN\\name form"
+      - name: passwordStoragePath
+        title: Password Storage Path
         type: String
         required: false
+        description: "Path to the Password to use within Rundeck Storage. E.g. keys/path/my.password. Can be overridden by a Node attribute named 'ssh-password-storage-path'."
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "user"
-      - name: pass
-        title: Password
-        description: "Password"
-        type: String
-        required: false
-        scope: Instance
-        renderingOptions:
-          displayType: PASSWORD
+          selectionAccessor: "STORAGE_PATH"
+          valueConversion: "STORAGE_PATH_AUTOMATIC_READ"
+          storage-path-root: "keys"
+          storage-file-meta-filter: "Rundeck-data-type=password"
+          instance-scope-node-attribute: "password-storage-path"
       - name: authtype
         title: Auth type
-        description: "Authentication type"
+        description: "Authentication type.Can be overridden by a Node attribute named 'authtype'."
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
         default: "plaintext"
@@ -50,7 +47,7 @@ providers:
           instance-scope-node-attribute: "authtype"
       - name: allowoverride
         title: Allow Override
-        description: "Gives possibility to override hostname, username (and password) in job options"
+        description: "Gives possibility to override hostname, username (and password) in job options.Can be overridden by a Node attribute named 'allowoverride'."
         type: Select
         values: "none, host, user, all"
         default: "none"
@@ -60,7 +57,7 @@ providers:
           instance-scope-node-attribute: "allowoverride"
       - name: winrmport
         title: WinRM port
-        description: "WinRM port (Default: 5985/5986 for http/https)"
+        description: "WinRM port (Default: 5985/5986 for http/https).Can be overridden by a Node attribute named 'winrmport'."
         type: String
         default: "5985"
         required: true
@@ -69,7 +66,7 @@ providers:
           instance-scope-node-attribute: "winrmport"
       - name: shell
         title: Shell
-        description: "Windows interpreter"
+        description: "Windows interpreter.Can be overridden by a Node attribute named 'shell'."
         type: Select
         values: "cmd, powershell, wql"
         default: 'powershell'
@@ -79,12 +76,19 @@ providers:
           instance-scope-node-attribute: "shell"
       - name: winrmtimeout
         title: WinRM timeout
-        description: "timeout in seconds default: 60"
+        description: "timeout in seconds default: 60. Can be overridden by a Node attribute named 'winrmtimeout'."
         type: Integer
         required: false
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "winrmtimeout"
+      - name: nosslpv
+        title: No SSL Peer Verification
+        type: Boolean
+        description: "Enable/Disable the ssl peer verificacion ( eg: no_ssl_peer_verification => true). Can be overridden by a Node attribute named 'no-ssl-peer-verification'."
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "no-ssl-peer-verification"          
   - name: WinRMcp
     title: WinRM File Copier
     service: FileCopier
@@ -97,29 +101,25 @@ providers:
         title: Kerberos Realm
         type: String
         required: false
-        description: "Kerberos Realm FQDN in capital letters"
+        description: "Kerberos Realm FQDN in capital letters.Can be overridden by a Node attribute named 'krb5_realm'."
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "krb5_realm"
-      - name: user
-        title: Username
+      - name: passwordStoragePath
+        title: Password Storage Path
         type: String
         required: false
-        description: "Username in DOMAIN\\name form"
+        description: "Path to the Password to use within Rundeck Storage. E.g. keys/path/my.password. Can be overridden by a Node attribute named 'ssh-password-storage-path'."
         scope: Instance
         renderingOptions:
-          instance-scope-node-attribute: "user"
-      - name: pass
-        title: Password
-        type: String
-        required: false
-        description: "Password"
-        scope: Instance
-        renderingOptions:
-          displayType: PASSWORD
+          selectionAccessor: "STORAGE_PATH"
+          valueConversion: "STORAGE_PATH_AUTOMATIC_READ"
+          storage-path-root: "keys"
+          storage-file-meta-filter: "Rundeck-data-type=password"
+          instance-scope-node-attribute: "password-storage-path"
       - name: authtype
         title: Auth type
-        description: "Authentication type"
+        description: "Authentication type.Can be overridden by a Node attribute named 'authtype'."
         type: Select
         values: "negotiate, ssl, kerberos, plaintext"
         default: "plaintext"
@@ -129,7 +129,7 @@ providers:
           instance-scope-node-attribute: "authtype"
       - name: allowoverride
         title: Allow Override
-        description: "Gives possibility to override hostname, username (and password) in job options"
+        description: "Gives possibility to override hostname, username (and password) in job options.Can be overridden by a Node attribute named 'allowoverride'."
         type: Select
         values: "none, host, user, all"
         default: "none"
@@ -139,7 +139,7 @@ providers:
           instance-scope-node-attribute: "allowoverride"
       - name: winrmport
         title: WinRM port
-        description: "WinRM port (Default: 5985/5986 for http/https)"
+        description: "WinRM port (Default: 5985/5986 for http/https).Can be overridden by a Node attribute named 'winrmport'."
         type: String
         default: "5985"
         required: true
@@ -148,7 +148,7 @@ providers:
           instance-scope-node-attribute: "winrmport"
       - name: shell
         title: Shell
-        description: "Windows interpreter. Should be same as in Executor"
+        description: "Windows interpreter. Should be same as in Executor.Can be overridden by a Node attribute named 'shell'."
         type: Select
         values: "cmd, powershell, wql"
         default: 'powershell'
@@ -158,9 +158,16 @@ providers:
           instance-scope-node-attribute: "shell"
       - name: winrmtimeout
         title: WinRM timeout
-        description: "timeout in seconds default: 60"
+        description: "timeout in seconds default: 60. Can be overridden by a Node attribute named 'winrmtimeout'."
         type: Integer
         required: false
         scope: Instance
         renderingOptions:
           instance-scope-node-attribute: "winrmtimeout"
+      - name: nosslpv
+        title: No SSL Peer Verification
+        type: Boolean
+        description: "Enable/Disable the ssl peer verificacion ( eg: no_ssl_peer_verification => true). Can be overridden by a Node attribute named 'no-ssl-peer-verification'."
+        scope: Instance
+        renderingOptions:
+          instance-scope-node-attribute: "no-ssl-peer-verification" 


### PR DESCRIPTION
New config option in order to take the username from the node definition and the password for the key storage (which can also be added on the node definition). Also I added and a new config option to define if the ssl connection skip the ssl cert verification.